### PR TITLE
serveのポートを可変化

### DIFF
--- a/demo4.js
+++ b/demo4.js
@@ -1,0 +1,6 @@
+//import { serveAPI } from "https://code4fukui.github.io/wsutil/wsutil.js";
+import { serveAPI } from "./wsutil.js";
+
+serveAPI("/api", async (param, req, path, conninfo) => {
+  return { response: "OK", param };
+}, 8888);

--- a/wsutil.js
+++ b/wsutil.js
@@ -13,10 +13,10 @@ program
 
 const options = program.opts();
 
-const port = parseInt((program.processedArgs ? program.processedArgs[0] : null) || 8000);
 const hostname = options.ipv4 ? "0.0.0.0" : "[::]";
 
-export const serve = (handle) => { // func(req, path, conninfo)
+export const serve = (handle, defaultPort = 8000) => { // func(req, path, conninfo)
+  const port = parseInt((program.processedArgs ? program.processedArgs[0] : null) || defaultPort);
   _serve(async (req, conninfo) => {
     const path = new URL(req.url).pathname;
     return await handle(req, path, conninfo);

--- a/wsutil.js
+++ b/wsutil.js
@@ -23,7 +23,7 @@ export const serve = (handle, defaultPort = 8000) => { // func(req, path, connin
   }, { port, hostname });
 };
 
-export const serveAPI = (apipath, func) => { // func(param, req, path, conninfo)
+export const serveAPI = (apipath, func, defaultPort = 8000) => { // func(param, req, path, conninfo)
   serve(async (req, path, conninfo) => {
     if (req.method == "OPTIONS") {
       const headers = {
@@ -37,5 +37,5 @@ export const serveAPI = (apipath, func) => { // func(param, req, path, conninfo)
       return await handleAPI(func, req, path, conninfo);
     }
     return await handleWeb("static", req, path, conninfo);
-  });
+  }, defaultPort);
 };


### PR DESCRIPTION
ポートが8000に固定されていたのを引数で指定できるようにしました、デフォルトで8000なので互換性も保たれているはずです